### PR TITLE
fix(hide): clear previous defer timeout

### DIFF
--- a/dist/tiny-toast.js
+++ b/dist/tiny-toast.js
@@ -57,6 +57,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict'
 
 	var tinyToast
+	var deferTimeoutId
 
 	function createCssStyleSheet () {
 	  // code taken from
@@ -122,8 +123,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 	function maybeDefer (fn, timeoutMs) {
+	  clearTimeout(deferTimeoutId)
+
 	  if (timeoutMs) {
-	    setTimeout(fn, timeoutMs)
+	    deferTimeoutId = setTimeout(fn, timeoutMs)
 	  } else {
 	    fn()
 	  }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var tinyToast
+var deferTimeoutId
 
 function createCssStyleSheet () {
   // code taken from
@@ -66,8 +67,10 @@ function closeMessage () {
 }
 
 function maybeDefer (fn, timeoutMs) {
+  clearTimeout(deferTimeoutId)
+
   if (timeoutMs) {
-    setTimeout(fn, timeoutMs)
+    deferTimeoutId = setTimeout(fn, timeoutMs)
   } else {
     fn()
   }


### PR DESCRIPTION
Hey, thanks for this library. It's great for a simple tutorial I'm creating. One thing I noticed is that if I do something like:

```
tinyToast.show('Test 1').hide(1000);
setTimeout(function() {
  tinyToast.show('Test 2').hide(1000);
}, 900);
```

The second toast only gets shown for 100 milliseconds, whereas I would expect it to be shown for a full second. To fix it, we just need to clear out the timeout from the previous `hide()` call as I've done in this PR. Any interest in merging this?
